### PR TITLE
Add createTask function with use server directive for task creation

### DIFF
--- a/src/app/task/add/page.tsx
+++ b/src/app/task/add/page.tsx
@@ -1,4 +1,19 @@
 import Link from "next/link"
+import prisma from "@/utils/db";
+
+async function createTask(formData:FormData){
+    "use server";
+    const title = formData.get("title")?.toString()
+    const description = formData.get("description")?.toString()
+
+    if(!title || !description) return console.log("Required")
+
+    await prisma.task.create({
+        data:{
+            title,description
+        }
+    })
+}
 
 function AddTaskPage() {
     return (
@@ -8,7 +23,7 @@ function AddTaskPage() {
             </Link>
             <div className="w-2/3 mx-auto rounded-md p-5 bg-slate-800 bottom-2 border-gray-300">
                 <h1 className="mb-7 font-bold text-3xl">Add Your Task</h1>
-                <form action="" className="flex flex-col gap-6">
+                <form action={createTask} className="flex flex-col gap-6">
                     <input type="text" placeholder="Task Title" name="title" className="p-2 text-xl rounded-md text-gray-950"/>
                     <textarea name="description" rows={5} placeholder="Task Description" className="p-2 text-xl rounded-md text-gray-950 resize-none"/>
                     <button type="submit" className="bg-cyan-300 text-black font-semibold text-xl rounded-md p-3 transition-colors" >Add Task</button>


### PR DESCRIPTION
- Implemented `createTask` function to handle task creation using Prisma.
- Added "use server" directive to ensure the function runs on the server side.
- Updated the AddTaskPage form to use `createTask` as the action handler for form submission.
- Included validation to check for required fields (title and description) before creating a task.
- Maintained consistent styling for the form and page layout using Tailwind CSS.